### PR TITLE
Patches to 0.5.6 release

### DIFF
--- a/bundle-2.2/pom.xml
+++ b/bundle-2.2/pom.xml
@@ -24,7 +24,7 @@
         <groupId>za.co.absa.spline.agent.spark</groupId>
         <artifactId>spline-spark-agent_2.11</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>0.5.6</version>
+        <version>0.5.6-kensu-spark20fix</version>
     </parent>
 
     <dependencies>

--- a/bundle-2.3/pom.xml
+++ b/bundle-2.3/pom.xml
@@ -24,7 +24,7 @@
         <groupId>za.co.absa.spline.agent.spark</groupId>
         <artifactId>spline-spark-agent_2.11</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>0.5.6</version>
+        <version>0.5.6-kensu-spark20fix</version>
     </parent>
 
     <dependencies>

--- a/bundle-2.4/pom.xml
+++ b/bundle-2.4/pom.xml
@@ -24,7 +24,7 @@
         <groupId>za.co.absa.spline.agent.spark</groupId>
         <artifactId>spline-spark-agent_2.11</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>0.5.6</version>
+        <version>0.5.6-kensu-spark20fix</version>
     </parent>
 
     <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -25,7 +25,7 @@
         <groupId>za.co.absa.spline.agent.spark</groupId>
         <artifactId>spline-spark-agent_2.11</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>0.5.6</version>
+        <version>0.5.6-kensu-spark20fix</version>
     </parent>
 
     <properties>

--- a/core/src/main/scala/za/co/absa/spline/harvester/builder/write/WriteNodeBuilder.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/builder/write/WriteNodeBuilder.scala
@@ -42,7 +42,7 @@ class WriteNodeBuilder
       append = command.mode == SaveMode.Append,
       id = id,
       childIds = childIds.toList,
-      schema = None,
+      schema = Some(outputSchema),
       params = Map(command.params.toSeq: _*).asOption,
       extra = Map(
         OperationExtras.Name -> command.name,

--- a/core/src/main/scala/za/co/absa/spline/harvester/converter/ExpressionConverter.scala
+++ b/core/src/main/scala/za/co/absa/spline/harvester/converter/ExpressionConverter.scala
@@ -81,7 +81,16 @@ class ExpressionConverter(
         getExpressionExtraParameters(e))
   }
 
-  private def getDataType(expr: SparkExpression) = dataTypeConverter.convert(expr.dataType, expr.nullable)
+  private def getDataType(expr: SparkExpression) = {
+    import za.co.absa.spline.model.dt.Simple
+    import scala.util.Try
+    // some expressions like WindowSpec.dataType throws UnsupportedOperationException
+    val sparkNullable = Try(expr.nullable).toOption.getOrElse(true)
+    val datatypeFromSpark = Try(expr.dataType)
+      .toOption
+      .map(sparkDataType => dataTypeConverter.convert(sparkDataType, sparkNullable))
+    datatypeFromSpark.getOrElse(Simple("unknown", nullable = sparkNullable))
+  }
 }
 
 object ExpressionConverter {

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -24,7 +24,7 @@
         <groupId>za.co.absa.spline.agent.spark</groupId>
         <artifactId>spline-spark-agent_2.11</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>0.5.6</version>
+        <version>0.5.6-kensu-spark20fix</version>
     </parent>
 
     <dependencies>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -22,7 +22,7 @@
         <groupId>za.co.absa.spline.agent.spark</groupId>
         <artifactId>spline-spark-agent_2.11</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>0.5.6</version>
+        <version>0.5.6-kensu-spark20fix</version>
     </parent>
 
     <artifactId>integration-tests_2.11</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <artifactId>spline-spark-agent_2.11</artifactId>
     <name>Spline Spark Agent</name>
     <description>Spline Agent for Apache Spark</description>
-    <version>0.5.6</version>
+    <version>0.5.6-kensu-spark20fix</version>
 
     <packaging>pom</packaging>
 
@@ -104,7 +104,7 @@
         <url>${scm.url}</url>
         <connection>${scm.connection}</connection>
         <developerConnection>${scm.developerConnection}</developerConnection>
-        <tag>release/0.5.6</tag>
+        <tag>release/0.5.6-kensu-spark20fix</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -325,21 +325,25 @@
                 <groupId>org.apache.spark</groupId>
                 <artifactId>spark-core_${scala.binary.version}</artifactId>
                 <version>${spark.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.spark</groupId>
                 <artifactId>spark-sql_${scala.binary.version}</artifactId>
                 <version>${spark.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.spark</groupId>
                 <artifactId>spark-hive_${scala.binary.version}</artifactId>
                 <version>${spark.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.spark</groupId>
                 <artifactId>spark-sql-kafka-0-10_${scala.binary.version}</artifactId>
                 <version>${spark.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>com.databricks</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -425,26 +425,31 @@
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
                 <version>1.13</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>commons-lang</groupId>
                 <artifactId>commons-lang</artifactId>
                 <version>2.6</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.9</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>commons-configuration</groupId>
                 <artifactId>commons-configuration</artifactId>
                 <version>1.10</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>2.6</version>
+                <scope>provided</scope>
             </dependency>
 
             <!-- Logging -->

--- a/pom.xml
+++ b/pom.xml
@@ -83,9 +83,9 @@
         <!-- Spark -->
 
         <spark.version>${spark-24.version}</spark.version>
-        <spark-22.version>2.2.2</spark-22.version>
+        <spark-22.version>2.2.0</spark-22.version>
         <spark-23.version>2.3.2</spark-23.version>
-        <spark-24.version>2.4.2</spark-24.version>
+        <spark-24.version>2.4.4</spark-24.version>
 
         <!-- Cross build properties -->
 
@@ -206,6 +206,10 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
+                    <configuration>
+                        <source>1.7</source>
+                        <target>1.7</target>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>com.github.cerveada</groupId>


### PR DESCRIPTION
basically same as in earlier repo https://github.com/AbsaOSS/spline/compare/develop...kensuio:0.4.0-kensu-spark20fix (fix hive for spark 2.2.0 & rarer datatypes) with addition of:
- additional jarhell fixes (mark more dependencies as provided)
- preserve outputSchema

